### PR TITLE
fixes a problem where calling `init.bat /v` would not work correctly

### DIFF
--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -9,6 +9,11 @@
 :: Use -v command line arg or set to > 0 for verbose output to aid in debugging.
 set verbose-output=0
 
+:: Get the absolute path to the default working directory
+pushd %0\..\..
+set "CMDER_ROOT_DEFAULT=%CD%"
+popd
+
 :var_loop
     if "%~1" == "" (
         goto :start
@@ -55,7 +60,7 @@ if not defined CMDER_ROOT (
     if defined ConEmuDir (
         for /f "delims=" %%i in ("%ConEmuDir%\..\..") do set "CMDER_ROOT=%%~fi"
     ) else (
-        for /f "delims=" %%i in ("%~dp0\..") do set "CMDER_ROOT=%%~fi"
+        set CMDER_ROOT=%CMDER_ROOT_DEFAULT%
     )
 )
 
@@ -378,4 +383,3 @@ exit /b
 
     :: looks like we have the same versions.
     exit /b 0
-

--- a/vendor/init.bat
+++ b/vendor/init.bat
@@ -402,7 +402,7 @@ exit /b
 
     :: looks like we have the same versions.
     exit /b 0
-    
+
 :enhance_path
     setlocal enabledelayedexpansion
     set "find_query=%~1"


### PR DESCRIPTION
This seems to fix a problem where calling `init.bat /v` directly from any directory would fail to set the `%CMDER_ROOT%` variable if `%ConEmuDir%` is also not set (e.g. not using ConEmu with Cmder.)

<img width="498" alt="fixed_init_verb" src="https://user-images.githubusercontent.com/4673812/36604831-14ba8732-18d4-11e8-8b0e-7035c02d62a3.png">
